### PR TITLE
vite configuration file updated - production build folder name changed to /build and build folder added in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ lerna-debug.log*
 node_modules
 dist
 dist-ssr
+build
 *.local
 
 # Editor directories and files

--- a/vite.config.js
+++ b/vite.config.js
@@ -7,5 +7,8 @@ export default defineConfig({
   server: {
     host: 'localhost',
     port: 3001
+  },
+  build: {
+    outDir: "build"
   }
 })


### PR DESCRIPTION
vite configuration file updated - production build folder name changed to /build and build folder added in gitignore